### PR TITLE
Also allow use of backordering function

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -18,8 +18,7 @@ class Data extends \Magento\ConfigurableProduct\Helper\Data
             $productId = $product->getId();
 
             $product = $objectManager->get('Magento\Catalog\Model\Product')->load($productId);
-            $stockitem = $stockRegistry->getStockItem($product->getId(), $product->getStore()->getWebsiteId());
-            if($stockitem->getQty() == 0) continue;
+            if($product->isSaleable() == false) continue;
 
             $images = $this->getGalleryImages($product);
             if ($images) {


### PR DESCRIPTION
Check if product isSaleable() instead of retrieving stock quantity, in order to allow the backordering of configurable product options being 'In Stock'/Saleable, but with Qty <= 0.